### PR TITLE
[H1]-Add Docker file for Hasura and PostgreSQL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+db_data
 # Logs
 logs
 *.log

--- a/README.md
+++ b/README.md
@@ -1,1 +1,5 @@
 # Hasura-Project
+
+## Docker
+
+Run with command `docker-compose up`

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Hasura-Project
 
-## Docker
+## Run Docker container
 
-Run with command `docker-compose up`
+Run with command `docker-compose up` and check if Hasura is working on `http://localhost:8080/`. You can login on local pgAdmin with `http://localhost:5050/`, using default user/password: pgadmin4@pgadmin.org/admin and host `postgres`.
+
+To stop hit `Ctrl+c`

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,31 @@
+version: '3.6'
+services:
+  postgres:
+    image: postgres:12
+    restart: always
+    volumes:
+    - db_data:/var/lib/postgresql/data
+    environment:
+      POSTGRES_PASSWORD: postgrespassword
+  graphql-engine:
+    image: hasura/graphql-engine:v2.2.0
+    ports:
+    - "8080:8080"
+    depends_on:
+    - "postgres"
+    restart: always
+    environment:
+      ## postgres database to store Hasura metadata
+      HASURA_GRAPHQL_METADATA_DATABASE_URL: postgres://postgres:postgrespassword@postgres:5432/postgres
+      ## this env var can be used to add the above postgres database to Hasura as a data source. this can be removed/updated based on your needs
+      PG_DATABASE_URL: postgres://postgres:postgrespassword@postgres:5432/postgres
+      ## enable the console served by server
+      HASURA_GRAPHQL_ENABLE_CONSOLE: "true" # set to "false" to disable console
+      ## enable debugging mode. It is recommended to disable this in production
+      HASURA_GRAPHQL_DEV_MODE: "true"
+      HASURA_GRAPHQL_ENABLED_LOG_TYPES: startup, http-log, webhook-log, websocket-log, query-log
+      ## uncomment next line to set an admin secret
+      # HASURA_GRAPHQL_ADMIN_SECRET: myadminsecretkey
+volumes:
+  db_data:
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,15 @@ services:
       - ./db_data:/var/lib/postgresql/data
     environment:
       POSTGRES_PASSWORD: postgrespassword
+  pgadmin:
+    image: fenglc/pgadmin4
+    container_name: pgadmin
+    env_file:
+      - ./.env
+    depends_on:
+      - postgres
+    ports:
+      - 5050:5050
   graphql-engine:
     image: hasura/graphql-engine:v2.2.0
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,18 +1,18 @@
-version: '3.6'
+version: "3.6"
 services:
   postgres:
     image: postgres:12
     restart: always
     volumes:
-    - db_data:/var/lib/postgresql/data
+      - ./db_data:/var/lib/postgresql/data
     environment:
       POSTGRES_PASSWORD: postgrespassword
   graphql-engine:
     image: hasura/graphql-engine:v2.2.0
     ports:
-    - "8080:8080"
+      - "8080:8080"
     depends_on:
-    - "postgres"
+      - "postgres"
     restart: always
     environment:
       ## postgres database to store Hasura metadata
@@ -28,4 +28,3 @@ services:
       # HASURA_GRAPHQL_ADMIN_SECRET: myadminsecretkey
 volumes:
   db_data:
-


### PR DESCRIPTION
With this PR we add a Docker yaml file for Hasura and PostgreSQL.

You have two services inside docker.yaml

Check this [link](https://hasura.io/docs/latest/graphql/core/hasura-cli/config-reference.html#environment-variables) for Hasura Env Variables